### PR TITLE
Fix confirmation email parameters

### DIFF
--- a/testEmail.js
+++ b/testEmail.js
@@ -1,6 +1,6 @@
 const sendConfirmationEmail = require("./utils/sendConfirmationEmail");
 
-sendConfirmationEmail("ahmedmoalshendidi@gmail.com", "Ahmed")
+sendConfirmationEmail("ahmedmoalshendidi@gmail.com", "Ahmed Test", 12345, 100)
   .then(() => {
     console.log("✅ Test email sent successfully.");
   })

--- a/utils/sendConfirmationEmail.js
+++ b/utils/sendConfirmationEmail.js
@@ -3,9 +3,11 @@ const axios = require('axios');
 /**
  * Send confirmation email to the customer
  * @param {string} email - Customer's email address
- * @param {string} firstName - Customer's first name
+ * @param {string} fullName - Customer's full name
+ * @param {number} orderId - Related Paymob order ID
+ * @param {number} amount - Paid amount in EGP
  */
-const sendConfirmationEmail = async (email, firstName) => {
+const sendConfirmationEmail = async (email, fullName, orderId, amount) => {
   try {
     const response = await axios.post('https://api.mailersend.com/v1/email', {
       from: {
@@ -15,12 +17,12 @@ const sendConfirmationEmail = async (email, firstName) => {
       to: [
         {
           email,
-          name: firstName
+          name: fullName
         }
       ],
       subject: "Booking Confirmation",
-      text: `Hi ${firstName},\n\nThank you for booking your tour with Buddy Tour!`,
-      html: `<h3>Hi ${firstName},</h3><p>Thank you for booking your tour with <strong>Buddy Tour</strong>!</p>`
+      text: `Hi ${fullName},\n\nThank you for booking your tour with Buddy Tour!\nOrder ID: ${orderId}\nAmount Paid: EGP ${amount}`,
+      html: `<h3>Hi ${fullName},</h3><p>Thank you for booking your tour with <strong>Buddy Tour</strong>!</p><p>Order ID: <strong>${orderId}</strong></p><p>Amount Paid: <strong>EGP ${amount}</strong></p>`
     }, {
       headers: {
         Authorization: `Bearer ${process.env.MAILERSEND_API_TOKEN}`,


### PR DESCRIPTION
## Summary
- update email sender util to use full name and order details
- adjust example email test

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68895ee226708324bd00675b18970f9a