### PR TITLE
Fix catch-all route for Express 5

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,9 @@ app.get("/payment/failure", (req, res) => {
   res.sendFile(path.join(__dirname, "public/fail.html"));
 });
 
-app.get("*", (req, res) => {
+// Path-to-RegExp v8 requires a named wildcard parameter
+// for catch-all routes instead of using "*" directly.
+app.get("/*rest", (req, res) => {
   res.sendFile(path.join(__dirname, "client/dist/index.html"));
 });
 


### PR DESCRIPTION
## Summary
- use a named wildcard for the catch-all route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68899fea84808324a584871f0814715d