### PR TITLE
Simplify checkout countdown and remove unused import

### DIFF
--- a/frontend/components/CheckoutProcess.tsx
+++ b/frontend/components/CheckoutProcess.tsx
@@ -233,24 +233,16 @@ export default function CheckoutProcess({ onBack }: CheckoutProcessProps) {
           <div className="lg:col-span-1 space-y-6">
             {/* Countdown Timer - Above Booking Summary */}
             {holdExpiration && (
-              <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-                <div className="flex items-center justify-center mb-2">
-                  <span className="text-amber-800 font-medium text-sm">🔒 We'll hold your spot for</span>
-                </div>
-                <CountdownTimer
-                  expirationTime={holdExpiration.toISOString()}
-                  className="!bg-amber-100 !border-amber-300 !text-amber-900"
-                  onExpire={() => {
-                    setHoldExpiration(null);
-                    // Redirect back to tour selection or show expired message
-                    alert('Your seat reservation has expired. Please select your seats again.');
-                    onBack();
-                  }}
-                />
-                <div className="text-center mt-2">
-                  <span className="text-amber-700 text-xs">Complete your booking before the timer expires</span>
-                </div>
-              </div>
+              <CountdownTimer
+                expirationTime={holdExpiration.toISOString()}
+                className="!bg-amber-100 !border-amber-300 !text-amber-900"
+                onExpire={() => {
+                  setHoldExpiration(null);
+                  // Redirect back to tour selection or show expired message
+                  alert('Your seat reservation has expired. Please select your seats again.');
+                  onBack();
+                }}
+              />
             )}
             
             <BookingSummary 

--- a/frontend/components/TicketsQuantity.tsx
+++ b/frontend/components/TicketsQuantity.tsx
@@ -9,7 +9,6 @@ import DateSelector from './booking/DateSelector';
 import TimeSelector from './booking/TimeSelector';
 import TicketCounter from './booking/TicketCounter';
 import PriceDisplay from './booking/PriceDisplay';
-import CountdownTimer from './ui/CountdownTimer';
 import { useCart } from './CartContext';
 
 interface Tour {


### PR DESCRIPTION
## Summary
- render a single `CountdownTimer` in checkout sidebar to avoid duplicate messages
- drop unused `CountdownTimer` import from ticket quantity step

## Testing
- `npm test` *(fails: Tours API integration test expecting different SQL query)*

------
https://chatgpt.com/codex/tasks/task_e_68bb66a6a53c8324bfd493adfcb4b2ac